### PR TITLE
Guess encoding names with nkf module

### DIFF
--- a/lib/kudzu/model/page.rb
+++ b/lib/kudzu/model/page.rb
@@ -92,8 +92,8 @@ module Kudzu
 
       def decode_body(body)
         if text?
-          if find_encoding
-            body.dup.force_encoding(charset).encode('utf-8', invalid: :replace, undef: :replace)
+          if enc = find_encoding(body)
+            body.dup.force_encoding(enc).encode('utf-8', invalid: :replace, undef: :replace)
           else
             body.dup.encode('utf-8', invalid: :replace, undef: :replace)
           end
@@ -102,8 +102,10 @@ module Kudzu
         end
       end
 
-      def find_encoding
-        Encoding.find(charset)
+      def find_encoding(body)
+        require 'nkf'
+        enc = NKF.guess(body)
+        enc.name
       rescue
         nil
       end

--- a/spec/dummy/public/test/charset/cp932.html
+++ b/spec/dummy/public/test/charset/cp932.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="Shift_JIS" />
+  <title>cp932.html.title</title>
+</head>
+<body>
+  ⅠⅡⅢ①②③
+  cp932.html.body 本文です
+</body>
+</html>

--- a/spec/dummy/public/test/index.html
+++ b/spec/dummy/public/test/index.html
@@ -46,6 +46,7 @@
   <ul class="charset">
     <li><a href="charset/shift_jis.html">shift_jis</a></li>
     <li><a href="charset/euc-jp.html">euc-jp</a></li>
+    <li><a href="charset/cp932.html">cp932</a></li>
     <li><a href="charset/none.html">none</a></li>
     <li><a href="charset/unknown.html">unknown</a></li>
   </ul>


### PR DESCRIPTION
CP932の文字（ローマ数字Ⅱなど）が文字化けするためNKFモジュールで文字コードを推測しエンコーディングするように修正しました。