### PR TITLE
Encode content-disposition contents

### DIFF
--- a/lib/kudzu/agent/fetcher.rb
+++ b/lib/kudzu/agent/fetcher.rb
@@ -80,10 +80,15 @@ module Kudzu
 
       def build_response(url, response, response_time, redirect_from)
         fetched = response.instance_variable_get("@read")
+        response_header = Hash[response.each.to_a]
+        if response_header.has_key?('content-disposition') &&
+           response_header['content-disposition']
+          response_header['content-disposition'].force_encoding('utf-8')
+        end
         Response.new(url: url,
                      status: response.code.to_i,
                      body: fetched ? response.body.to_s : nil,
-                     response_header: Hash[response.each.to_a],
+                     response_header: response_header,
                      response_time: response_time,
                      redirect_from: redirect_from,
                      fetched: fetched)

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -17,6 +17,14 @@ class ApplicationController < ActionController::Base
     render plain: '', status: 500
   end
 
+  def image_file_jp
+    send_file Rails.root.join('public/test/files/jpeg1.jpg'), filename: 'テスト.jpg'
+  end
+
+  def image_file_en
+    send_file Rails.root.join('public/test/files/jpeg1.jpg'), filename: 'test.jpg'
+  end
+
   private
 
   def set_cookie

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -4,4 +4,6 @@ Rails.application.routes.draw do
   get 'not_modified' => 'application#not_modified'
   get 'gone' => 'application#gone'
   get 'internal_server_error' => 'application#internal_server_error'
+  get 'image_file_jp' => 'application#image_file_jp'
+  get 'image_file_en' => 'application#image_file_en'
 end

--- a/spec/dummy/public/test/index.html
+++ b/spec/dummy/public/test/index.html
@@ -77,6 +77,10 @@
     <li><a href="/gone">gone</a></li>
     <li><a href="/internal_server_error">internal_server_error</a></li>
   </ul>
+  <ul class="download">
+    <li><a href="/image_file_jp">download(JP)</a></li>
+    <li><a href="/image_file_en">download(EN)</a></li>
+  </ul>
   <ul class="other-protocol">
     <li><a href="javascript:void(0)">javascript</a></li>
     <li><a href="tel:***-****">tel</a></li>


### PR DESCRIPTION
Errors occur when content-disposition in response header includes Japanese contents
(e.g. content-dispotion="inline; filename=ダウンロード.jpg").