### PR TITLE
Fix path-to-directory conversion

### DIFF
--- a/lib/kudzu/common.rb
+++ b/lib/kudzu/common.rb
@@ -15,7 +15,8 @@ module Kudzu
         if path.end_with?('/')
           path
         else
-          File.dirname(path) + '/'
+          dir = File.dirname(path)
+          dir.end_with?('/') ? dir : dir + '/'
         end
       end
     end

--- a/spec/dummy/public/index.html
+++ b/spec/dummy/public/index.html
@@ -6,5 +6,8 @@
 </head>
 <body>
   index.html
+  <ul class="html">
+    <li><a href="test/index.html">test</a></li>
+  </ul>
 </body>
 </html>

--- a/spec/kudzu/crawler_spec.rb
+++ b/spec/kudzu/crawler_spec.rb
@@ -1,5 +1,6 @@
 describe Kudzu::Crawler do
   let(:seed_url) { "http://localhost:9292/test/index.html" }
+  let(:seed_url_top) { "http://localhost:9292/index.html" }
   let(:config_file) { Rails.root.join('config/kudzu.rb') }
 
   before {
@@ -63,6 +64,12 @@ describe Kudzu::Crawler do
     it 'with configs' do
       crawler = Kudzu::Crawler.new(config_file: config_file)
       crawler.run(seed_url)
+      expect(crawler.repository.page.size > 0).to be_truthy
+    end
+
+    it 'crawl from a top page' do
+      crawler = Kudzu::Crawler.new(config_file: config_file)
+      crawler.run(seed_url_top)
       expect(crawler.repository.page.size > 0).to be_truthy
     end
   end


### PR DESCRIPTION
When paramter: focus_descendants is true and top page is accessed (e.g. http://example.com/index.html), the subordinate pages (e.g. http://example.com/test/index.html) cannot be accessed. This is caused by errors of path_to_dir function in kudzu/common.rb.